### PR TITLE
Fix/environment variables dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "index.js",
   "scripts": {
     "build": "tsc",
-    "start": "node src/index.js",
-    "start:local": "npm run build && node src/index.js",
+    "start": "node -r dotenv/config src/index.js",
+    "start:local": "npm run build && node -r dotenv/config src/index.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],


### PR DESCRIPTION
Closes #1 

### Description
`dotenv` dependency was missing from the project. In the screenshot below, @nhcarrigan instructed to install it and add it with the commands.
<img width="779" alt="Screen Shot 2021-05-08 at 18 27 36" src="https://user-images.githubusercontent.com/61970868/117543058-45247980-b02c-11eb-9e24-d48a409593c3.png">

I had to give you credit Nick, thank you so much for the help.

### Proposed solution:
1- Running `npm install dotenv`
2- Editing `package.json` commands as follows:
```diff
-    "start": "node src/index.js",
-    "start:local": "npm run build && node src/index.js",
+    "start": "node -r dotenv/config src/index.js",
+    "start:local": "npm run build && node -r dotenv/config src/index.js",
```